### PR TITLE
🔧 Fix Windows PowerShell compatibility in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,26 +295,44 @@ jobs:
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
-      - name: Get version from Linux job
-        if: matrix.platform != 'linux'
-        id: get-version
+      - name: Get version from Linux job (macOS)
+        if: matrix.platform == 'macos'
+        id: get-version-mac
+        shell: bash
         run: |
           # Wait a moment for tag to be available
           sleep 10
-
+          
           # Get the latest tag
           git fetch --tags
           LATEST_TAG=$(git describe --tags --abbrev=0)
           VERSION=${LATEST_TAG#v}
-
+          
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+      
+      - name: Get version from Linux job (Windows)
+        if: matrix.platform == 'windows'
+        id: get-version-win
+        shell: pwsh
+        run: |
+          # Wait a moment for tag to be available
+          Start-Sleep -Seconds 10
+          
+          # Get the latest tag
+          git fetch --tags
+          $LATEST_TAG = git describe --tags --abbrev=0
+          $VERSION = $LATEST_TAG -replace '^v', ''
+          
+          echo "version=$VERSION" >> $env:GITHUB_OUTPUT
+          echo "tag=$LATEST_TAG" >> $env:GITHUB_OUTPUT
 
       - name: Build application
         run: pnpm run build
 
       - name: Package application (Linux)
         if: matrix.platform == 'linux'
+        shell: bash
         run: |
           pnpm run package:linux
           echo "📦 Linux packages created:"
@@ -322,15 +340,17 @@ jobs:
 
       - name: Package application (Windows)
         if: matrix.platform == 'windows'
+        shell: pwsh
         run: |
           pnpm run package:win
-          echo "📦 Windows packages created:"
-          dir release/build/
+          Write-Host "📦 Windows packages created:"
+          Get-ChildItem release/build/
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Package application (macOS)
         if: matrix.platform == 'macos'
+        shell: bash
         run: |
           pnpm run package:mac
           echo "📦 macOS packages created:"
@@ -354,7 +374,7 @@ jobs:
         if: matrix.platform == 'windows'
         uses: actions/upload-artifact@v4
         with:
-          name: windows-packages-${{ steps.get-version.outputs.version }}
+          name: windows-packages-${{ steps.get-version-win.outputs.version }}
           path: |
             release/build/*.exe
             release/build/*.msi
@@ -364,7 +384,7 @@ jobs:
         if: matrix.platform == 'macos'
         uses: actions/upload-artifact@v4
         with:
-          name: macos-packages-${{ steps.get-version.outputs.version }}
+          name: macos-packages-${{ steps.get-version-mac.outputs.version }}
           path: |
             release/build/*.dmg
             release/build/*.zip


### PR DESCRIPTION
## 🎯 Problem

The release workflow is failing on Windows because it's trying to run bash commands in PowerShell:

```
LATEST_TAG=$(git describe --tags --abbrev=0): Line 7 | LATEST_TAG=$(git describe --tags --abbrev=0)
The term 'LATEST_TAG=$(git describe --tags --abbrev=0)' is not recognized as a cmdlet...
Error: Process completed with exit code 1.
```

## 🔧 Solution

This PR fixes cross-platform shell compatibility issues in the CI release workflow:

### **Windows PowerShell Fixes:**
- ✅ Add explicit `shell: pwsh` for Windows steps  
- ✅ Convert bash syntax to PowerShell equivalents
- ✅ Use PowerShell variables (`$env:GITHUB_OUTPUT` vs `$GITHUB_OUTPUT`)
- ✅ Replace `echo` with `Write-Host` and `dir` with `Get-ChildItem`
- ✅ Use `Start-Sleep` instead of `sleep`

### **Step Reference Fixes:**
- ✅ Update artifact upload steps to use correct step IDs
- ✅ Windows: `steps.get-version-win.outputs.version`
- ✅ macOS: `steps.get-version-mac.outputs.version`  
- ✅ Linux: `steps.version.outputs.version` (unchanged)

### **Shell Consistency:**
- ✅ Linux packaging: `shell: bash`
- ✅ macOS packaging: `shell: bash`
- ✅ Windows packaging: `shell: pwsh`

## 🧪 Testing

This will allow the automated release system to work correctly across all platforms (Windows, macOS, Linux) without shell compatibility errors.

## 📋 Files Changed

- `.github/workflows/ci.yml` - Updated release workflow for cross-platform compatibility

---

**Related to original error**: Resolves PowerShell command recognition errors in Windows CI builds.