### PR TITLE
🚨 Critical Fix: Handle missing git tags in CI release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
 
           # Get the latest tag
           git fetch --tags
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           VERSION=${LATEST_TAG#v}
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -321,7 +321,14 @@ jobs:
 
           # Get the latest tag
           git fetch --tags
-          $LATEST_TAG = git describe --tags --abbrev=0
+          try {
+            $LATEST_TAG = git describe --tags --abbrev=0 2>$null
+          } catch {
+            $LATEST_TAG = "v0.0.0"
+          }
+          if (-not $LATEST_TAG) {
+            $LATEST_TAG = "v0.0.0"
+          }
           $VERSION = $LATEST_TAG -replace '^v', ''
 
           echo "version=$VERSION" >> $env:GITHUB_OUTPUT
@@ -406,7 +413,7 @@ jobs:
         id: get-tag
         run: |
           git fetch --tags
-          LATEST_TAG=$(git describe --tags --abbrev=0)
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           VERSION=${LATEST_TAG#v}
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## 🎯 Problem

CI release workflow is failing with:
```
fatal: No names found, cannot describe anything.
Error: Process completed with exit code 128.
```

This occurs because the repository has no git tags yet, but the workflow tries to use `git describe --tags --abbrev=0` without proper error handling.

## ✅ Root Cause Analysis

The issue is in three locations in the CI workflow:

1. **macOS Job (Line 308)**: Missing fallback when no tags exist
2. **Windows Job (Line 324)**: No PowerShell error handling  
3. **Publish Release Job (Line 409)**: Missing fallback when no tags exist

The Linux job (Line 259) already had proper fallback: `|| echo "v0.0.0"` ✅

## 🔧 Solution

**Fixed all three locations:**

### macOS Job
```bash
# Before (fails)
LATEST_TAG=$(git describe --tags --abbrev=0)

# After (safe)  
LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
```

### Windows Job (PowerShell)
```powershell
# Before (fails)
$LATEST_TAG = git describe --tags --abbrev=0

# After (safe)
try {
  $LATEST_TAG = git describe --tags --abbrev=0 2>$null
} catch {
  $LATEST_TAG = "v0.0.0"
}
if (-not $LATEST_TAG) {
  $LATEST_TAG = "v0.0.0"
}
```

### Publish Release Job
```bash
# Before (fails)
LATEST_TAG=$(git describe --tags --abbrev=0)

# After (safe)
LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
```

## 🧪 Testing Strategy

This fix ensures that:
- ✅ **New repositories**: Start with v0.0.0 fallback
- ✅ **Existing repositories**: Continue using actual latest tag
- ✅ **Cross-platform**: Works on Linux, macOS, and Windows  
- ✅ **No functional changes**: Only error handling improvements

## 📋 Impact

- **🚨 Blocks**: All CI/CD and releases currently failing
- **✅ Fixes**: Release workflow failures for new repositories
- **🔄 Enables**: Proper versioning and automated releases
- **⚡ Priority**: Critical - blocks all development workflow

---

**This is a critical fix that unblocks the entire CI/CD pipeline. Without this, no releases can be created.**