### PR TITLE
🔥 Hotfix: Remove non-existent type-check script from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
-      - name: TypeScript check
-        run: pnpm run type-check
-
   build:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🚨 **Critical CI Fix**

This is a hotfix to resolve the CI failures that are blocking the development workflow after the release system redesign merge.

## 🎯 **Problem**

The CI lint job is failing with:


## ✅ **Root Cause**

The CI workflow was trying to run  ERR_PNPM_NO_SCRIPT  Missing script: type-check

Command "type-check" not found. Did you mean "pnpm run format:check"?, but this script doesn't exist in . TypeScript checking is actually handled by the build job through webpack's .

## 🔧 **Solution**

- ❌ **Removed**:  ERR_PNPM_NO_SCRIPT  Missing script: type-check

Command "type-check" not found. Did you mean "pnpm run format:check"? from the lint job
- ✅ **Kept**: TypeScript checking in the build job (via webpack)
- ✅ **Result**: CI can now pass and development workflow is unblocked

## 🏃‍♂️ **Why This is a Hotfix**

This is blocking:
- ✅ All PR merges (CI must pass)
- ✅ Development workflow 
- ✅ Testing the new release system

## 📋 **Changes**

- Remove 3 lines from 
- No functional changes to TypeScript checking (still happens in build job)
- Zero impact on code quality or type safety

---

**This unblocks the CI pipeline and allows us to test the new release system. 🚀**