### PR TITLE
ci: fix artifact paths in build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           name: build-output
           path: |
-            build/
+            dist/
             release/build/
           retention-days: 7
 


### PR DESCRIPTION
This PR fixes the 'No files were found' warning in the CI build job by updating the artifact paths to match the actual build output locations.

## Changes
- Update artifact paths in CI workflow
- Change 'build/' to 'dist/' to match webpack output
- Keep 'release/build/' for electron-builder output

## Testing
- CI build job should now correctly find and upload artifacts
- No more 'No files were found' warning

## Related Issues
- Fixes artifact upload warning in CI build job