### PR TITLE
Release fix 1

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -112,14 +112,14 @@ jobs:
           fi
 
           TAG="v$VERSION"
-          
+
           # Check if tag already exists
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "❌ Error: Tag $TAG already exists!"
             echo "Please use a different version or delete the existing tag first."
             exit 1
           fi
-          
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
@@ -187,9 +187,9 @@ jobs:
           title: '🚀 Release ${{ steps.version.outputs.tag }}'
           body: |
             ## 🚀 Release ${{ steps.version.outputs.tag }}
-            
+
             This PR contains the version bump for the upcoming release.
-            
+
             ### Changes
             - 📦 Bump version to `${{ steps.version.outputs.version }}` in package.json
             - 🏷️ Tag `${{ steps.version.outputs.tag }}` has been created            ### Release Process

--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
-      version: ${{ steps.version.outputs.version }}
-      tag: ${{ steps.version.outputs.tag }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
+      is_manual: ${{ steps.check.outputs.is_manual }}
+      input_version: ${{ steps.check.outputs.input_version }}
+      input_prerelease: ${{ steps.check.outputs.input_prerelease }}
     steps:
       - name: Check if release should proceed
         id: check
@@ -40,20 +40,57 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Manual release triggered"
             echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "is_manual=true" >> $GITHUB_OUTPUT
+            echo "input_version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            echo "input_prerelease=${{ inputs.prerelease }}" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "workflow_run" && "${{ github.event.workflow_run.conclusion }}" == "success" ]]; then
             echo "CI passed - auto release enabled"
-            echo "should_release=true" >> $GITHUB_OUTPUT  # Enable auto-release with branch protection
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "is_manual=false" >> $GITHUB_OUTPUT
+            echo "input_version=" >> $GITHUB_OUTPUT
+            echo "input_prerelease=false" >> $GITHUB_OUTPUT
           else
             echo "Release conditions not met"
             echo "should_release=false" >> $GITHUB_OUTPUT
-          fi
+            echo "is_manual=false" >> $GITHUB_OUTPUT
+            echo "input_version=" >> $GITHUB_OUTPUT
+            echo "input_prerelease=false" >> $GITHUB_OUTPUT
+          fi  # Create tag and update version
+  create-tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    needs: [check-trigger]
+    if: needs.check-trigger.outputs.should_release == 'true'
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+      release_branch: ${{ steps.version_update.outputs.release_branch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
-      - name: Set version information
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: Determine version information
         id: version
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version }}"
-            PRERELEASE="${{ inputs.prerelease }}"
+          if [[ "${{ needs.check-trigger.outputs.is_manual }}" == "true" ]]; then
+            VERSION="${{ needs.check-trigger.outputs.input_version }}"
+            PRERELEASE="${{ needs.check-trigger.outputs.input_prerelease }}"
+            echo "📋 Manual release version: $VERSION"
           else
             # Auto-increment patch version from current package.json
             echo "🔍 Determining next auto-release version..."
@@ -75,14 +112,14 @@ jobs:
           fi
 
           TAG="v$VERSION"
-
+          
           # Check if tag already exists
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "❌ Error: Tag $TAG already exists!"
             echo "Please use a different version or delete the existing tag first."
             exit 1
           fi
-
+          
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
@@ -91,38 +128,10 @@ jobs:
           echo "✅ Tag: $TAG"
           echo "✅ Pre-release: $PRERELEASE"
 
-  # Create tag and update version
-  create-tag:
-    name: Create Release Tag
-    runs-on: ubuntu-latest
-    needs: [check-trigger]
-    if: needs.check-trigger.outputs.should_release == 'true'
-    outputs:
-      version: ${{ needs.check-trigger.outputs.version }}
-      tag: ${{ needs.check-trigger.outputs.tag }}
-      prerelease: ${{ needs.check-trigger.outputs.prerelease }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '18'
-          cache: 'pnpm'
-
       - name: Update package.json version
         run: |
-          VERSION="${{ needs.check-trigger.outputs.version }}"
-          TAG="${{ needs.check-trigger.outputs.tag }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
           RELEASE_BRANCH="release/$TAG"
 
           echo "Updating package.json to version $VERSION"
@@ -175,17 +184,15 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
           branch: ${{ steps.version_update.outputs.release_branch }}
           base: main
-          title: '🚀 Release ${{ needs.check-trigger.outputs.tag }}'
+          title: '🚀 Release ${{ steps.version.outputs.tag }}'
           body: |
-            ## 🚀 Release ${{ needs.check-trigger.outputs.tag }}
-
+            ## 🚀 Release ${{ steps.version.outputs.tag }}
+            
             This PR contains the version bump for the upcoming release.
-
+            
             ### Changes
-            - 📦 Bump version to `${{ needs.check-trigger.outputs.version }}` in package.json
-            - 🏷️ Tag `${{ needs.check-trigger.outputs.tag }}` has been created
-
-            ### Release Process
+            - 📦 Bump version to `${{ steps.version.outputs.version }}` in package.json
+            - 🏷️ Tag `${{ steps.version.outputs.tag }}` has been created            ### Release Process
             1. ✅ Version updated and tagged
             2. 🔄 Building packages for all platforms
             3. 📝 GitHub release will be created automatically


### PR DESCRIPTION
This pull request refactors the release workflow in `.github/workflows/electron-release.yml` to improve handling of manual and automatic releases and clarify the flow of versioning and tagging information between jobs. The main changes include splitting the logic for checking release triggers and creating tags into separate jobs, updating output variables, and ensuring consistent use of version and tag information throughout the workflow.

Workflow refactoring and job separation:

* Split the release trigger check and tag creation into distinct jobs (`check-trigger` and `create-tag`), improving maintainability and clarity of the workflow steps.

Improved handling of manual vs. automatic releases:

* Added new outputs (`is_manual`, `input_version`, `input_prerelease`) to the `check-trigger` job to differentiate between manual and automatic releases, and updated downstream jobs to use these outputs for versioning decisions.

Consistent use of outputs:

* Updated the `create-tag` job and subsequent steps to use outputs from the correct job (`steps.version.outputs.*` instead of `needs.check-trigger.outputs.*`), ensuring accurate version, tag, and prerelease information is propagated.

Release PR improvements:

* Modified the release pull request title and body to use the correct output variables for version and tag, resulting in clearer and more accurate release documentation.