### PR TITLE
fix: update packaging steps to build without publishing for all platf…

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -269,28 +269,38 @@ jobs:
       - name: Package for Linux
         if: matrix.platform == 'linux'
         run: |
-          pnpm run package:linux
+          # Build without publishing to avoid auto-publish issues
+          pnpm run build && electron-builder --linux --publish never
           echo "📦 Linux packages created:"
           ls -la release/build/
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES: true
 
       - name: Package for Windows
         if: matrix.platform == 'windows'
         shell: pwsh
         run: |
-          pnpm run package:win
+          # Build without publishing to avoid auto-publish issues
+          pnpm run build && electron-builder --win --publish never
           Write-Host "📦 Windows packages created:"
           Get-ChildItem release/build/
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES: true
 
       - name: Package for macOS
         if: matrix.platform == 'macos'
         run: |
-          pnpm run package:mac
+          # Build without publishing to avoid auto-publish issues
+          pnpm run build && electron-builder --mac --publish never
           echo "📦 macOS packages created:"
           ls -la release/build/
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES: true
 
       - name: Upload Linux artifacts
         if: matrix.platform == 'linux'


### PR DESCRIPTION
This pull request updates the packaging steps for the Electron release workflow to improve reliability and avoid issues with auto-publishing. The changes focus on building for each platform without triggering automatic publishing, and add environment variables to support the build process.

Packaging process improvements:

* For Linux, Windows, and macOS, replaced the platform-specific `pnpm run package` commands with explicit build steps using `pnpm run build` and `electron-builder` with the `--publish never` flag to prevent auto-publishing issues.

Environment variable updates:

* Added the `GH_TOKEN` environment variable for all platforms to support Electron Builder operations.
* Added `ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES: true` for all platforms to allow unresolved dependencies during packaging