### PR TITLE
fix: update build commands to use pnpm exec for electron-builder

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -319,8 +319,8 @@ jobs:
       - name: Package for Linux
         if: matrix.platform == 'linux'
         run: |
-          # Build without publishing to avoid auto-publish issues
-          pnpm run build && electron-builder --linux --publish never
+          # Use pnpm exec to ensure electron-builder is found in PATH
+          pnpm exec electron-builder --linux --publish never
           echo "📦 Linux packages created:"
           ls -la release/build/
         env:
@@ -331,8 +331,8 @@ jobs:
         if: matrix.platform == 'windows'
         shell: pwsh
         run: |
-          # Build without publishing to avoid auto-publish issues
-          pnpm run build && electron-builder --win --publish never
+          # Use pnpm exec to ensure electron-builder is found in PATH
+          pnpm exec electron-builder --win --publish never
           Write-Host "📦 Windows packages created:"
           Get-ChildItem release/build/
         env:
@@ -343,8 +343,8 @@ jobs:
       - name: Package for macOS
         if: matrix.platform == 'macos'
         run: |
-          # Build without publishing to avoid auto-publish issues
-          pnpm run build && electron-builder --mac --publish never
+          # Use pnpm exec to ensure electron-builder is found in PATH
+          pnpm exec electron-builder --mac --publish never
           echo "📦 macOS packages created:"
           ls -la release/build/
         env:


### PR DESCRIPTION
This pull request updates the packaging steps in the `.github/workflows/electron-release.yml` workflow to use `pnpm exec` for running `electron-builder`. This change ensures that the correct binary is used and avoids issues with the PATH in CI environments.

Packaging workflow improvements:

* Updated the Linux packaging step to use `pnpm exec electron-builder` instead of running the build and then `electron-builder`, ensuring the correct binary is used and simplifying the command. (.github/workflows/electron-release.yml)
* Updated the Windows packaging step to use `pnpm exec electron-builder`, improving reliability and consistency with other platforms. (.github/workflows/electron-release.yml)
* Updated the macOS packaging step to use `pnpm exec electron-builder`, matching the approach used for Linux and Windows. (.github/workflows/electron-release.yml)