### PR TITLE
Add Spec Kit workspace storage and IPC bridging

### DIFF
--- a/src/common/spec-kit.ts
+++ b/src/common/spec-kit.ts
@@ -1,0 +1,72 @@
+export interface SpecKitWorkspaceKey {
+  org: string;
+  repo: string;
+  feature: string;
+}
+
+export type SpecKitWorkspaceId = string;
+
+export type SpecKitPromptRole = 'system' | 'user' | 'assistant';
+
+export interface SpecKitPromptMessage {
+  id: string;
+  role: SpecKitPromptRole;
+  content: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpecKitSpecRevision {
+  id: string;
+  summary?: string;
+  createdAt: string;
+  author?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpecKitGeneratedPatchPointer {
+  id: string;
+  description?: string;
+  path: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SpecKitWorkspaceMetadata {
+  promptHistory: SpecKitPromptMessage[];
+  specRevisions: SpecKitSpecRevision[];
+  generatedPatchPointers: SpecKitGeneratedPatchPointer[];
+  [key: string]: unknown;
+}
+
+export interface SpecKitWorkspace {
+  id: SpecKitWorkspaceId;
+  key: SpecKitWorkspaceKey;
+  title?: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  archived: boolean;
+  metadata: SpecKitWorkspaceMetadata;
+}
+
+export interface CreateSpecKitWorkspaceInput {
+  key: SpecKitWorkspaceKey;
+  title?: string;
+  description?: string;
+  metadata?: Partial<SpecKitWorkspaceMetadata>;
+}
+
+export interface UpdateSpecKitWorkspaceMetadataInput {
+  key: SpecKitWorkspaceKey;
+  metadata: SpecKitWorkspaceMetadata;
+}
+
+export interface ArchiveSpecKitWorkspaceInput {
+  key: SpecKitWorkspaceKey;
+  archived?: boolean;
+}
+
+export interface SpecKitWorkspaceSelectionState {
+  currentWorkspaceId: SpecKitWorkspaceId | null;
+}

--- a/src/main/ipc/capability-enforcer.ts
+++ b/src/main/ipc/capability-enforcer.ts
@@ -165,6 +165,20 @@ export const CAPABILITIES: Record<string, CapabilityDescriptor> = {
     riskLevel: 'critical',
     category: 'app',
   },
+
+  // Spec Kit capabilities
+  'specKit.read': {
+    name: 'specKit.read',
+    description: 'Read Spec Kit workspaces and metadata',
+    riskLevel: 'low',
+    category: 'app',
+  },
+  'specKit.manage': {
+    name: 'specKit.manage',
+    description: 'Create or modify Spec Kit workspaces',
+    riskLevel: 'medium',
+    category: 'app',
+  },
 };
 
 /**

--- a/src/main/ipc/schemas.ts
+++ b/src/main/ipc/schemas.ts
@@ -105,6 +105,88 @@ export const MarketplaceGetStatusSchema = z.object({ pluginId: nonEmptyString })
 export const ShowOpenDialogSchema = z.object({ options: z.any() }); // Could be more specific
 export const ShowSaveDialogSchema = z.object({ options: z.any() });
 
+// Spec Kit workspaces
+export const SpecKitWorkspaceKeySchema = z.object({
+  org: nonEmptyString,
+  repo: nonEmptyString,
+  feature: nonEmptyString,
+});
+
+const SpecKitPromptMessageSchema = z
+  .object({
+    id: nonEmptyString,
+    role: z.enum(['system', 'user', 'assistant']),
+    content: z.string(),
+    createdAt: nonEmptyString,
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+const SpecKitSpecRevisionSchema = z
+  .object({
+    id: nonEmptyString,
+    summary: z.string().optional(),
+    createdAt: nonEmptyString,
+    author: z.string().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+const SpecKitPatchPointerSchema = z
+  .object({
+    id: nonEmptyString,
+    description: z.string().optional(),
+    path: nonEmptyString,
+    createdAt: nonEmptyString,
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+const SpecKitWorkspaceMetadataSchema = z
+  .object({
+    promptHistory: z.array(SpecKitPromptMessageSchema),
+    specRevisions: z.array(SpecKitSpecRevisionSchema),
+    generatedPatchPointers: z.array(SpecKitPatchPointerSchema),
+  })
+  .passthrough();
+
+const SpecKitWorkspaceMetadataInputSchema = z
+  .object({
+    promptHistory: z.array(SpecKitPromptMessageSchema).optional(),
+    specRevisions: z.array(SpecKitSpecRevisionSchema).optional(),
+    generatedPatchPointers: z.array(SpecKitPatchPointerSchema).optional(),
+  })
+  .passthrough();
+
+export const SpecKitListWorkspacesSchema = z.object({});
+
+export const SpecKitCreateWorkspaceSchema = z.object({
+  key: SpecKitWorkspaceKeySchema,
+  title: z.string().optional(),
+  description: z.string().optional(),
+  metadata: SpecKitWorkspaceMetadataInputSchema.optional(),
+});
+
+export const SpecKitGetWorkspaceSchema = z.object({
+  key: SpecKitWorkspaceKeySchema,
+});
+
+export const SpecKitUpdateWorkspaceMetadataSchema = z.object({
+  key: SpecKitWorkspaceKeySchema,
+  metadata: SpecKitWorkspaceMetadataSchema,
+});
+
+export const SpecKitArchiveWorkspaceSchema = z.object({
+  key: SpecKitWorkspaceKeySchema,
+  archived: z.boolean().optional(),
+});
+
+export const SpecKitSelectWorkspaceSchema = z.object({
+  key: SpecKitWorkspaceKeySchema,
+});
+
+export const SpecKitGetCurrentWorkspaceSchema = z.object({});
+
 export type FileReadFileInput = z.infer<typeof FileReadFileSchema>;
 export type FileReadFileTextInput = z.infer<typeof FileReadFileTextSchema>;
 export type CommandExecuteInput = z.infer<typeof CommandExecuteSchema>;

--- a/src/main/ipc/spec-kit-ipc.ts
+++ b/src/main/ipc/spec-kit-ipc.ts
@@ -1,0 +1,68 @@
+import { registerValidated } from './validators';
+import { IPCManager } from '../ipc-manager';
+import { Logger } from '../logger';
+import { SpecKitWorkspaceManager } from '../spec-kit-workspace-manager';
+import {
+  SpecKitArchiveWorkspaceSchema,
+  SpecKitCreateWorkspaceSchema,
+  SpecKitGetWorkspaceSchema,
+  SpecKitListWorkspacesSchema,
+  SpecKitSelectWorkspaceSchema,
+  SpecKitUpdateWorkspaceMetadataSchema,
+  SpecKitGetCurrentWorkspaceSchema,
+} from './schemas';
+
+export function registerSpecKitIPC(
+  ipc: IPCManager,
+  logger: Logger,
+  workspaceManager: SpecKitWorkspaceManager
+): void {
+  registerValidated(ipc, logger, {
+    channel: 'specKit:listWorkspaces',
+    schema: SpecKitListWorkspacesSchema,
+    capability: 'specKit.read',
+    handler: async () => workspaceManager.listWorkspaces(),
+  });
+
+  registerValidated(ipc, logger, {
+    channel: 'specKit:createWorkspace',
+    schema: SpecKitCreateWorkspaceSchema,
+    capability: 'specKit.manage',
+    handler: async input => workspaceManager.createWorkspace(input),
+  });
+
+  registerValidated(ipc, logger, {
+    channel: 'specKit:getWorkspace',
+    schema: SpecKitGetWorkspaceSchema,
+    capability: 'specKit.read',
+    handler: async input => workspaceManager.getWorkspace(input.key),
+  });
+
+  registerValidated(ipc, logger, {
+    channel: 'specKit:updateWorkspaceMetadata',
+    schema: SpecKitUpdateWorkspaceMetadataSchema,
+    capability: 'specKit.manage',
+    handler: async input => workspaceManager.updateWorkspaceMetadata(input.key, input.metadata),
+  });
+
+  registerValidated(ipc, logger, {
+    channel: 'specKit:archiveWorkspace',
+    schema: SpecKitArchiveWorkspaceSchema,
+    capability: 'specKit.manage',
+    handler: async input => workspaceManager.archiveWorkspace(input),
+  });
+
+  registerValidated(ipc, logger, {
+    channel: 'specKit:selectWorkspace',
+    schema: SpecKitSelectWorkspaceSchema,
+    capability: 'specKit.manage',
+    handler: async input => workspaceManager.selectWorkspace(input.key),
+  });
+
+  registerValidated(ipc, logger, {
+    channel: 'specKit:getCurrentWorkspace',
+    schema: SpecKitGetCurrentWorkspaceSchema,
+    capability: 'specKit.read',
+    handler: async () => workspaceManager.getCurrentWorkspace(),
+  });
+}

--- a/src/main/lib/storage/spec-kit-storage.ts
+++ b/src/main/lib/storage/spec-kit-storage.ts
@@ -1,0 +1,242 @@
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import { Logger } from '../../logger';
+import {
+  ArchiveSpecKitWorkspaceInput,
+  CreateSpecKitWorkspaceInput,
+  SpecKitWorkspace,
+  SpecKitWorkspaceId,
+  SpecKitWorkspaceKey,
+  SpecKitWorkspaceMetadata,
+} from '../../../common/spec-kit';
+
+const INVALID_SEGMENT = /[\\/]/g;
+
+function sanitizeSegment(segment: string): string {
+  return segment.replace(INVALID_SEGMENT, '_');
+}
+
+function ensureMetadata(metadata?: Partial<SpecKitWorkspaceMetadata>): SpecKitWorkspaceMetadata {
+  return {
+    promptHistory: metadata?.promptHistory ? [...metadata.promptHistory] : [],
+    specRevisions: metadata?.specRevisions ? [...metadata.specRevisions] : [],
+    generatedPatchPointers: metadata?.generatedPatchPointers
+      ? [...metadata.generatedPatchPointers]
+      : [],
+  };
+}
+
+function workspaceIdFromKey(key: SpecKitWorkspaceKey): SpecKitWorkspaceId {
+  return `${key.org}/${key.repo}/${key.feature}`;
+}
+
+function parseWorkspaceId(id: SpecKitWorkspaceId): SpecKitWorkspaceKey {
+  const [org, repo, feature] = id.split('/');
+  if (!org || !repo || !feature) {
+    throw new Error(`Invalid workspace identifier: ${id}`);
+  }
+  return { org, repo, feature };
+}
+
+export class SpecKitStorage {
+  private basePath: string;
+  private logger: Logger;
+
+  constructor(logger = new Logger('SpecKitStorage')) {
+    this.logger = logger;
+    this.basePath = path.join(app.getPath('userData'), 'specKits');
+  }
+
+  async init(): Promise<void> {
+    await fsp.mkdir(this.basePath, { recursive: true });
+  }
+
+  static toId(key: SpecKitWorkspaceKey): SpecKitWorkspaceId {
+    return workspaceIdFromKey(key);
+  }
+
+  static fromId(id: SpecKitWorkspaceId): SpecKitWorkspaceKey {
+    return parseWorkspaceId(id);
+  }
+
+  private getWorkspaceDirectory(key: SpecKitWorkspaceKey): string {
+    return path.join(
+      this.basePath,
+      sanitizeSegment(key.org),
+      sanitizeSegment(key.repo)
+    );
+  }
+
+  private getWorkspaceFilePath(key: SpecKitWorkspaceKey): string {
+    return path.join(this.getWorkspaceDirectory(key), `${sanitizeSegment(key.feature)}.json`);
+  }
+
+  private async readWorkspaceFile(filePath: string): Promise<SpecKitWorkspace | null> {
+    try {
+      const content = await fsp.readFile(filePath, 'utf8');
+      const parsed = JSON.parse(content) as SpecKitWorkspace;
+      return this.normalizeWorkspace(parsed);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return null;
+      }
+      this.logger.warn(`Failed to read workspace file at ${filePath}`, error);
+      return null;
+    }
+  }
+
+  private normalizeWorkspace(raw: SpecKitWorkspace): SpecKitWorkspace {
+    const metadata = ensureMetadata(raw.metadata);
+    const key = raw.key ?? SpecKitStorage.fromId(raw.id);
+    const id = raw.id ?? SpecKitStorage.toId(key);
+    return {
+      id,
+      key,
+      title: raw.title,
+      description: raw.description,
+      createdAt: raw.createdAt ?? new Date().toISOString(),
+      updatedAt: raw.updatedAt ?? raw.createdAt ?? new Date().toISOString(),
+      archived: Boolean(raw.archived),
+      metadata,
+    };
+  }
+
+  async listWorkspaces(): Promise<SpecKitWorkspace[]> {
+    const results: SpecKitWorkspace[] = [];
+
+    let orgDirs: string[] = [];
+    try {
+      orgDirs = await fsp.readdir(this.basePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return results;
+      }
+      throw error;
+    }
+
+    for (const orgDir of orgDirs) {
+      const orgPath = path.join(this.basePath, orgDir);
+      const stat = await fsp.stat(orgPath);
+      if (!stat.isDirectory()) {
+        continue;
+      }
+
+      const repoDirs = await fsp.readdir(orgPath);
+      for (const repoDir of repoDirs) {
+        const repoPath = path.join(orgPath, repoDir);
+        const repoStat = await fsp.stat(repoPath);
+        if (!repoStat.isDirectory()) {
+          continue;
+        }
+
+        const featureFiles = await fsp.readdir(repoPath);
+        for (const fileName of featureFiles) {
+          if (!fileName.endsWith('.json')) {
+            continue;
+          }
+
+          const filePath = path.join(repoPath, fileName);
+          const workspace = await this.readWorkspaceFile(filePath);
+          if (workspace) {
+            results.push(workspace);
+          }
+        }
+      }
+    }
+
+    results.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return results;
+  }
+
+  async getWorkspace(key: SpecKitWorkspaceKey): Promise<SpecKitWorkspace | null> {
+    const filePath = this.getWorkspaceFilePath(key);
+    return this.readWorkspaceFile(filePath);
+  }
+
+  async getWorkspaceById(id: SpecKitWorkspaceId): Promise<SpecKitWorkspace | null> {
+    try {
+      const key = SpecKitStorage.fromId(id);
+      return this.getWorkspace(key);
+    } catch (error) {
+      this.logger.warn(`Failed to parse workspace id ${id}`, error);
+      return null;
+    }
+  }
+
+  async createWorkspace(input: CreateSpecKitWorkspaceInput): Promise<SpecKitWorkspace> {
+    const existing = await this.getWorkspace(input.key);
+    if (existing) {
+      throw new Error(`Workspace already exists for ${SpecKitStorage.toId(input.key)}`);
+    }
+
+    const now = new Date().toISOString();
+    const metadata = ensureMetadata(input.metadata);
+    const workspace: SpecKitWorkspace = {
+      id: SpecKitStorage.toId(input.key),
+      key: input.key,
+      title: input.title,
+      description: input.description,
+      createdAt: now,
+      updatedAt: now,
+      archived: false,
+      metadata,
+    };
+
+    await this.persist(workspace);
+    return workspace;
+  }
+
+  async updateMetadata(
+    key: SpecKitWorkspaceKey,
+    metadata: SpecKitWorkspaceMetadata
+  ): Promise<SpecKitWorkspace> {
+    const existing = await this.getWorkspace(key);
+    if (!existing) {
+      throw new Error(`Workspace not found for ${SpecKitStorage.toId(key)}`);
+    }
+
+    const updated: SpecKitWorkspace = {
+      ...existing,
+      metadata: ensureMetadata(metadata),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.persist(updated);
+    return updated;
+  }
+
+  async archiveWorkspace(
+    input: ArchiveSpecKitWorkspaceInput
+  ): Promise<SpecKitWorkspace> {
+    const existing = await this.getWorkspace(input.key);
+    if (!existing) {
+      throw new Error(`Workspace not found for ${SpecKitStorage.toId(input.key)}`);
+    }
+
+    const updated: SpecKitWorkspace = {
+      ...existing,
+      archived: input.archived ?? true,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.persist(updated);
+    return updated;
+  }
+
+  private async persist(workspace: SpecKitWorkspace): Promise<void> {
+    const filePath = this.getWorkspaceFilePath(workspace.key);
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      await fsp.mkdir(dir, { recursive: true });
+    }
+
+    const data = JSON.stringify(workspace, null, 2);
+    await fsp.writeFile(filePath, data, 'utf8');
+  }
+}
+
+export function createDefaultWorkspaceMetadata(): SpecKitWorkspaceMetadata {
+  return ensureMetadata();
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -20,6 +20,8 @@ import { registerExtensionIPC } from './ipc/extension-ipc';
 import { registerMarketplaceIPC } from './ipc/marketplace-ipc';
 import { registerAppControlIPC } from './ipc/app-control-ipc';
 import { getGlobalCapabilityEnforcer } from './ipc/capability-enforcer';
+import { SpecKitWorkspaceManager } from './spec-kit-workspace-manager';
+import { registerSpecKitIPC } from './ipc/spec-kit-ipc';
 
 class AppShell {
   private windowManager: WindowManager;
@@ -32,6 +34,7 @@ class AppShell {
   private fileSystemManager: FileSystemManager;
   private promptRegistryService: PromptRegistryService;
   private promptRegistryIPC: PromptRegistryIPCManager;
+  private specKitWorkspaceManager: SpecKitWorkspaceManager;
   private logger: Logger;
   private platform: Platform;
   private pathSecurity: PathSecurity;
@@ -54,6 +57,7 @@ class AppShell {
     this.fileSystemManager = new FileSystemManager();
     this.promptRegistryService = new PromptRegistryService();
     this.promptRegistryIPC = new PromptRegistryIPCManager(this.promptRegistryService);
+    this.specKitWorkspaceManager = new SpecKitWorkspaceManager(this.settingsManager);
 
     // Initialize path security with default roots
     this.pathSecurity = new PathSecurity({
@@ -74,6 +78,9 @@ class AppShell {
 
       // Initialize settings
       await this.settingsManager.init();
+
+      // Initialize Spec Kit workspace storage
+      await this.specKitWorkspaceManager.init();
 
       // Initialize file system manager
       await this.fileSystemManager.init();
@@ -226,6 +233,7 @@ class AppShell {
     registerExtensionIPC(this.ipcManager, this.logger, this.extensionManager);
     registerMarketplaceIPC(this.ipcManager, this.logger, this.marketplaceService);
     registerAppControlIPC(this.ipcManager, this.logger, this.platform);
+    registerSpecKitIPC(this.ipcManager, this.logger, this.specKitWorkspaceManager);
 
     // Register prompt registry IPC handlers
     this.promptRegistryIPC.registerHandlers();
@@ -256,6 +264,7 @@ class AppShell {
       enforcer.grantCapability('extensions.manage', rendererContext);
       enforcer.grantCapability('extensions.install', rendererContext);
       enforcer.grantCapability('command.execute', rendererContext);
+      enforcer.grantCapability('specKit.manage', rendererContext);
 
       this.logger.info('Granted default capabilities to main renderer');
     }

--- a/src/main/spec-kit-workspace-manager.ts
+++ b/src/main/spec-kit-workspace-manager.ts
@@ -1,0 +1,102 @@
+import { Logger } from './logger';
+import { SettingsManager } from './settings-manager';
+import {
+  ArchiveSpecKitWorkspaceInput,
+  CreateSpecKitWorkspaceInput,
+  SpecKitWorkspace,
+  SpecKitWorkspaceId,
+  SpecKitWorkspaceKey,
+  SpecKitWorkspaceMetadata,
+} from '../common/spec-kit';
+import { SpecKitStorage } from './lib/storage/spec-kit-storage';
+
+const CURRENT_WORKSPACE_SETTING_KEY = 'specKit.currentWorkspaceId';
+
+export class SpecKitWorkspaceManager {
+  private readonly logger = new Logger('SpecKitWorkspaceManager');
+  private readonly storage: SpecKitStorage;
+
+  constructor(private readonly settingsManager: SettingsManager) {
+    this.storage = new SpecKitStorage(this.logger);
+  }
+
+  async init(): Promise<void> {
+    await this.storage.init();
+  }
+
+  async listWorkspaces(): Promise<SpecKitWorkspace[]> {
+    return this.storage.listWorkspaces();
+  }
+
+  async getWorkspace(key: SpecKitWorkspaceKey): Promise<SpecKitWorkspace | null> {
+    return this.storage.getWorkspace(key);
+  }
+
+  async getWorkspaceById(id: SpecKitWorkspaceId): Promise<SpecKitWorkspace | null> {
+    return this.storage.getWorkspaceById(id);
+  }
+
+  async createWorkspace(input: CreateSpecKitWorkspaceInput): Promise<SpecKitWorkspace> {
+    const workspace = await this.storage.createWorkspace(input);
+    await this.setCurrentWorkspaceId(workspace.id);
+    return workspace;
+  }
+
+  async updateWorkspaceMetadata(
+    key: SpecKitWorkspaceKey,
+    metadata: SpecKitWorkspaceMetadata
+  ): Promise<SpecKitWorkspace> {
+    const workspace = await this.storage.updateMetadata(key, metadata);
+    return workspace;
+  }
+
+  async archiveWorkspace(input: ArchiveSpecKitWorkspaceInput): Promise<SpecKitWorkspace> {
+    const workspace = await this.storage.archiveWorkspace(input);
+    const currentId = await this.getCurrentWorkspaceId();
+    if (workspace.archived && currentId === workspace.id) {
+      await this.setCurrentWorkspaceId(null);
+    }
+    return workspace;
+  }
+
+  async selectWorkspace(key: SpecKitWorkspaceKey): Promise<SpecKitWorkspace> {
+    const workspace = await this.storage.getWorkspace(key);
+    if (!workspace) {
+      throw new Error(`Workspace not found for ${SpecKitStorage.toId(key)}`);
+    }
+    if (workspace.archived) {
+      throw new Error('Cannot select an archived workspace');
+    }
+    await this.setCurrentWorkspaceId(workspace.id);
+    return workspace;
+  }
+
+  async getCurrentWorkspace(): Promise<SpecKitWorkspace | null> {
+    const currentId = await this.getCurrentWorkspaceId();
+    if (!currentId) {
+      return null;
+    }
+    const workspace = await this.storage.getWorkspaceById(currentId);
+    if (!workspace || workspace.archived) {
+      await this.setCurrentWorkspaceId(null);
+      return null;
+    }
+    return workspace;
+  }
+
+  private async getCurrentWorkspaceId(): Promise<SpecKitWorkspaceId | null> {
+    const value = await this.settingsManager.get<string>(CURRENT_WORKSPACE_SETTING_KEY);
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+    return null;
+  }
+
+  private async setCurrentWorkspaceId(id: SpecKitWorkspaceId | null): Promise<void> {
+    if (id) {
+      await this.settingsManager.set(CURRENT_WORKSPACE_SETTING_KEY, id);
+    } else {
+      await this.settingsManager.set(CURRENT_WORKSPACE_SETTING_KEY, null);
+    }
+  }
+}

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -17,6 +17,13 @@ import {
   PromptRegistryConfig,
 } from '../schemas';
 import type { MarketplaceCategory, MarketplaceSearchResult } from '../types';
+import type {
+  ArchiveSpecKitWorkspaceInput,
+  CreateSpecKitWorkspaceInput,
+  SpecKitWorkspace,
+  SpecKitWorkspaceKey,
+  SpecKitWorkspaceMetadata,
+} from '../common/spec-kit';
 
 // Theme change event data interface
 interface ThemeChangeData {
@@ -161,6 +168,20 @@ interface ElectronAPI {
   onPromptImportCompleted?: (callback: (result: PromptImportResult) => void) => void;
   onPromptExportCompleted?: (callback: (result: PromptExportResult) => void) => void;
   removePromptEventListener?: (eventType: string, callback: (...args: any[]) => void) => void;
+
+  // Spec Kit Workspace Management
+  listSpecKitWorkspaces: () => Promise<SpecKitWorkspace[]>;
+  createSpecKitWorkspace: (input: CreateSpecKitWorkspaceInput) => Promise<SpecKitWorkspace>;
+  getSpecKitWorkspace: (key: SpecKitWorkspaceKey) => Promise<SpecKitWorkspace | null>;
+  updateSpecKitWorkspaceMetadata: (
+    key: SpecKitWorkspaceKey,
+    metadata: SpecKitWorkspaceMetadata
+  ) => Promise<SpecKitWorkspace>;
+  archiveSpecKitWorkspace: (
+    input: ArchiveSpecKitWorkspaceInput
+  ) => Promise<SpecKitWorkspace>;
+  selectSpecKitWorkspace: (key: SpecKitWorkspaceKey) => Promise<SpecKitWorkspace>;
+  getCurrentSpecKitWorkspace: () => Promise<SpecKitWorkspace | null>;
 }
 
 const extensionEventListeners = new Map<
@@ -363,6 +384,22 @@ const electronAPI: ElectronAPI = {
   }) => invokeSafe('prompt-registry:select-import-source', options || {}),
   selectExportTarget: (options?: { title?: string; defaultPath?: string }) =>
     invokeSafe('prompt-registry:select-export-target', options || {}),
+
+  // Spec Kit Workspace Management
+  listSpecKitWorkspaces: () => invokeSafe('specKit:listWorkspaces', {}),
+  createSpecKitWorkspace: (input: CreateSpecKitWorkspaceInput) =>
+    invokeSafe('specKit:createWorkspace', input),
+  getSpecKitWorkspace: (key: SpecKitWorkspaceKey) =>
+    invokeSafe('specKit:getWorkspace', { key }),
+  updateSpecKitWorkspaceMetadata: (
+    key: SpecKitWorkspaceKey,
+    metadata: SpecKitWorkspaceMetadata
+  ) => invokeSafe('specKit:updateWorkspaceMetadata', { key, metadata }),
+  archiveSpecKitWorkspace: (input: ArchiveSpecKitWorkspaceInput) =>
+    invokeSafe('specKit:archiveWorkspace', input),
+  selectSpecKitWorkspace: (key: SpecKitWorkspaceKey) =>
+    invokeSafe('specKit:selectWorkspace', { key }),
+  getCurrentSpecKitWorkspace: () => invokeSafe('specKit:getCurrentWorkspace', {}),
 
   // Prompt Registry Events
   onPromptAdded: (callback: (prompt: Prompt) => void) => {


### PR DESCRIPTION
## Summary
- add shared Spec Kit workspace types and filesystem-backed Spec Kit storage namespace
- implement a Spec Kit workspace manager with capability-enforced IPC endpoints
- expose Spec Kit workspace CRUD helpers to the renderer via the preload bridge

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_69069ef362bc8332a83f37aa683fab48